### PR TITLE
Revert to building from I2P repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM alpine:latest
 LABEL maintainer "Yehor Popovych <popovych.yegor@gmail.com>"
 
+# GIT TAG FOR BUILD
+ARG GIT_TAG=""
+ENV GIT_TAG=${GIT_TAG}
+
 # allowed hostnames for web ui
 ARG HOSTNAMES=""
 ENV HOSTNAMES=${HOSTNAMES}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,13 @@ ENV I2CP_PORT=${I2CP_PORT}
 RUN addgroup -g ${HOST_GID} i2psnark \
     && adduser -h /snark -G i2psnark -u ${HOST_UID} -D i2psnark
 
-RUN apk --no-cache add openjdk17-jre su-exec shadow
-
-ADD https://gitlab.com/i2pplus/I2P.Plus/-/jobs/artifacts/master/raw/i2psnark-standalone.zip?job=Java8 /tmp/i2psnark-standalone.zip
-
-RUN unzip -d /snark /tmp/i2psnark-standalone.zip \
+RUN apk --no-cache add git gettext apache-ant openjdk8 \
+    && git clone https://github.com/i2p/i2p.i2p.git /src \
+    && cd /src \
+    && if [ -n "${GIT_TAG}" ]; then git checkout tags/${GIT_TAG}; fi \
+    && ant i2psnark \
+    && mkdir -p /snark/config \
+    && unzip -d /snark /src/apps/i2psnark/java/i2psnark-standalone.zip \
     && sed -i 's/<Set name="host">127.0.0.1<\/Set>/<Set name="host">0.0.0.0<\/Set>/' /snark/i2psnark/jetty-i2psnark.xml \
     && echo "i2psnark.dir=/snark/downloads" > /snark/i2psnark.config.default \
     && echo "i2psnark.i2cpHost=${I2CP_HOST}" >> /snark/i2psnark.config.default \
@@ -40,8 +42,9 @@ RUN unzip -d /snark /tmp/i2psnark-standalone.zip \
     && echo "i2psnark.allowedHosts=${HOSTNAMES}" >> /snark/i2psnark/i2psnark-appctx.config \
     && chown -R i2psnark:i2psnark /snark \
     && cd /snark/i2psnark && ln -s ../config i2psnark.config.d \
-    && rm -rf /tmp/i2psnark-standalone.zip 
-
+    && rm -rf /src \
+    && apk --purge del git gettext apache-ant openjdk8 \
+    && apk --no-cache add openjdk8-jre-base su-exec shadow
 
 VOLUME /snark/config
 VOLUME /snark/downloads


### PR DESCRIPTION
Revert to building from I2P repo.

Uses latest I2P tag if `GIT_TAG` is not set.